### PR TITLE
Fix the check for the date field on None

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -110,7 +110,7 @@ class SolaxPlugin:
                 Domoticz.Log(f"SolaxPlugin: Last update time: {last_update_time_str}")
 
                 # Convert last update time to a datetime object
-                if last_update_time_str and last_update_time_str != "None":
+                if last_update_time_str is not None:
                     last_update_time = datetime.datetime.strptime(last_update_time_str, '%Y-%m-%d %H:%M:%S')
 
                     # Calculate the time difference between now and the last update time


### PR DESCRIPTION
Update the check for `last_update_time_str` to correctly check for `None` as a type.

* Change the condition from `if last_update_time_str and last_update_time_str != "None":` to `if last_update_time_str is not None:` in `plugin.py`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/galadril/Domoticz-SolaxCloud-Plugin?shareId=e0d6e7c3-ab69-47ca-b635-8195a791ac07).